### PR TITLE
Add staticmethod initializer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
     - pip install -e .
 
 script:
-    - python -c "import pyEM2; em = pyEM2.ExpressionMatrix('abc123', gene_capacity=100, cell_capacity=100)"
+    - pytest -v tests/

--- a/src/pyEM2.cpp
+++ b/src/pyEM2.cpp
@@ -30,6 +30,10 @@ PYBIND11_MODULE(pyEM2, m) {
     // There are two ways to construct an ExpressionMatrix in the C++ code,
     // 1. With a directory_name that doesn't exist and a creation parameters object
     // 2. With an existing directory_name that was created with constructor 1
+    //
+    // We're going to use method 1 in the __init__ of the python ExpressionMatrix
+    // class, and we'll expose method 2 via a static method called
+    // "from_existing_directory".
     py::class_<czi_em2::ExpressionMatrix>(m, "ExpressionMatrix")
         .def(py::init(&intialize_expression_matrix),
                 py::arg("directory_name"),
@@ -38,7 +42,13 @@ PYBIND11_MODULE(pyEM2, m) {
                 py::arg("cell_metadata_name_capacity")=1<<16,
                 py::arg("cell_metadata_value_capacity")=1<<28)
 
-        .def(py::init<std::string>(),
-                py::arg("directory_name"))
+        .def_static("from_existing_directory",
+            [](std::string directory_name) {
+                return std::unique_ptr<czi_em2::ExpressionMatrix>(
+                    new czi_em2::ExpressionMatrix(directory_name));
+            },
+            py::arg("existing_em2_directory")
+        )
+
     ;
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,57 @@
+import os
+import pytest
+
+import pyEM2
+
+def test_init(tmpdir):
+    """Test initialization of EM with all args in order."""
+    exp_mat = pyEM2.ExpressionMatrix(
+        os.path.join(str(tmpdir), "EM2"),
+        1000,
+        1000,
+        1000,
+        1000)
+
+    assert isinstance(exp_mat, pyEM2.ExpressionMatrix)
+
+
+def test_init_no_optionals(tmpdir):
+    """Test initialization of EM with no optional args."""
+    exp_mat = pyEM2.ExpressionMatrix(
+        os.path.join(str(tmpdir), "EM2"))
+
+    assert isinstance(exp_mat, pyEM2.ExpressionMatrix)
+
+
+def test_init_named_args(tmpdir):
+    """Test initializtion of EM with out of order, names kwargs."""
+    exp_mat = pyEM2.ExpressionMatrix(
+        os.path.join(str(tmpdir), "EM2"),
+        cell_metadata_value_capacity=1000,
+        cell_metadata_name_capacity=1000,
+        cell_capacity=1000,
+        gene_capacity=1000)
+
+    assert isinstance(exp_mat, pyEM2.ExpressionMatrix)
+
+def test_init_from_existing(tmpdir):
+    """Test initialization of EM using the from_existing_directory
+    staticmethod."""
+    dir_path = os.path.join(str(tmpdir), "EM2")
+    orig_exp_mat = pyEM2.ExpressionMatrix(dir_path)
+    assert isinstance(orig_exp_mat, pyEM2.ExpressionMatrix)
+    del orig_exp_mat
+
+    new_exp_mat = pyEM2.ExpressionMatrix.from_existing_directory(dir_path)
+    assert isinstance(new_exp_mat, pyEM2.ExpressionMatrix)
+
+def test_init_from_existing_fails_on_missing(tmpdir):
+    """Test that from_existing_directory fails when the directory
+    doesn't exist.
+    """
+    dir_path = os.path.join(str(tmpdir), "EM2")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        new_exp_mat = pyEM2.ExpressionMatrix.from_existing_directory(dir_path)
+
+    assert "No such file" in str(excinfo.value)


### PR DESCRIPTION
This takes the `ExpressionMatrix(existing_directory_name)` constructor and moves it into a staticmethod (sort of a classmethod I guess, the difference is less clear in pybind).

So when you want to create a brand new EM object, you create it like you would expect in python: `exp_mat = pyEM2.ExpressionMatrix("new_directory_name")`. But when you want to load an existing one, you use the staticmethod `exp_mat = pyEM2.ExpressionMatrix.from_existing_directory("existing_directory_name")`.

Ideally this should make it easy to add other initializers like from a numpy array or a scipy sparse matrix.